### PR TITLE
Support for attributes - avoid removing them as if they're unused

### DIFF
--- a/src/unused/clean.ts
+++ b/src/unused/clean.ts
@@ -149,7 +149,6 @@ const walkTreeRecursively = (
 	callback: (node: PhpParser.Node) => void,
 ) => {
 	callback(node)
-
 	for (const value of Object.values(node)) {
 		if (typeof value !== 'object' || value === null) {
 			continue
@@ -171,7 +170,6 @@ export default (source: string, items: FlatUseItem[]): FlatUseItem[] => {
 	const parser = new PhpParser.Engine({
 		parser: {
 			extractDoc: true,
-			php7: true,
 		},
 	})
 

--- a/src/unused/clean.ts
+++ b/src/unused/clean.ts
@@ -122,6 +122,10 @@ function* extractCommentTypeReferences(node: PhpParser.Comment): Generator<strin
 	}
 }
 
+function* extractAttributeTypeReferences(node: PhpParser.Attribute): Generator<string> {
+	yield node.name
+}
+
 const visitors: Record<string, ((node: any) => Generator<string>) | undefined> = {
 	*name(node: PhpParser.Name) {
 		switch (node.resolution) {
@@ -142,6 +146,10 @@ const visitors: Record<string, ((node: any) => Generator<string>) | undefined> =
 	*commentline(node: PhpParser.CommentLine) {
 		yield* extractCommentTypeReferences(node)
 	},
+
+	*attribute(node: PhpParser.Attribute) {
+		yield* extractAttributeTypeReferences(node)
+	},
 }
 
 const walkTreeRecursively = (
@@ -149,6 +157,7 @@ const walkTreeRecursively = (
 	callback: (node: PhpParser.Node) => void,
 ) => {
 	callback(node)
+	
 	for (const value of Object.values(node)) {
 		if (typeof value !== 'object' || value === null) {
 			continue


### PR DESCRIPTION
Add support for PHP 8 attributes, so they don't get removed as if they are unused.

Solves https://github.com/tarik02/js-php-imports/issues/3